### PR TITLE
If this.small.getStyle(p) returns a margin of 0px; 0px; 0px; 0px; the wr...

### DIFF
--- a/Source/Zoomer.js
+++ b/Source/Zoomer.js
@@ -67,6 +67,7 @@ var Zoomer = new Class({
 			var style = this.small.getStyle(p);
 			var dflt = 'auto';
 			if(['float', 'clear', 'border'].contains(p)) dflt = 'none';
+			if(p == 'margin') style = '0 auto';
 			if(p == 'padding') dflt = '0';
 			try {
 				this.small.setStyle(p, dflt);


### PR DESCRIPTION
...apper will no longer center the image. Instead the styling for the wrapper's margin should be 0 auto; so the small image is still centered. To be honest, I'm not sure if this is 100% effective across all situations. It worked for me. I upgraded from v1.8 to v1.9.3 and found that my images were no longer centered in the wrapper.
