### PR TITLE
Update Source/Zoomer.js

### DIFF
--- a/Source/Zoomer.js
+++ b/Source/Zoomer.js
@@ -24,7 +24,7 @@ var Zoomer = new Class({
 	
 	initialize: function(element, options) {
 		this.setOptions(options);
-		this.small = document.id(element);
+		this.small = document.id(element) || (Type.isElement(element) ? element : null);
 		if(!this.small.complete) {
 			this.small.addEvent('load', function() {
 				this.prepareSmall();


### PR DESCRIPTION
Allow to pass an Element as argument, apart from strings.
Images might not always have an id property likely in galleries :D
